### PR TITLE
Add a notice as `strict_front_matter` is available in Jekyll 3.5.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/jekyll_strict_front_matter.svg)](https://badge.fury.io/rb/jekyll_strict_front_matter)
 
+**This feature is now available in Jekyll 3.5.0 and later by adding `strict_front_matter: true` to `_config.yml`.**
+
 By default, if a page or a post in a Jekyll site has a syntax error in the front matter, Jekyll logs an error, does not render anything for the given document, and continues. The result is a site without any content for the page with the syntax errors.
 
 This can be confusing for people who build sites without looking at the CLI, such as those of us whose sites build in a CI. In these cases, we may wish for our build to fail if there are front matter syntax errors. [This PR](https://github.com/jekyll/jekyll/pull/5832/files) seeks to add a config option for that, but in the meantime this plugin exists to fill the gap. This plugin may also be used to add the option to sites using an older version of Jekyll.


### PR DESCRIPTION
Hi, I stumbled upon this plugin via a Web search :slightly_smiling_face:

It turns out this feature has been available in core Jekyll for a while now, so it makes sense to have a notice to tell people this plugin is probably not necessary anymore.